### PR TITLE
Add curl for basic healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN rm -rf ./node_modules/npm
 RUN du -sh ./node_modules/* | sort -nr | grep '\dM.*'
 
 FROM node:alpine as runner
+RUN apk update && apk add curl --no-cache
 COPY --from=builder /usr/src/app/dist /app/dist
 COPY --from=builder /usr/src/app/node_modules /app/node_modules
 


### PR DESCRIPTION
## Description
This change adds `curl` to the lemmy-ui container for basic Docker healthcheck purposes.

### Before
Without the change, any Docker healthcheck using `curl` will fail because the the command does not exist inside the container:
```
$ grep -A2 lemmy-ui docker-compose.yml
  lemmy-ui:
    image: dessalines/lemmy-ui:0.18.5
    healthcheck:
      test: curl -f http://127.0.0.1:1234 || exit 1
```

### After
With the change, a simple `curl` healthcheck shows the lemmy-ui container as healthy when correctly configured:
```
$ grep -A5 lemmy-ui docker-compose.yml
  lemmy-ui:
    image: dvlemmyui
    healthcheck:
      test: curl -f http://127.0.0.1:1234 || exit 1
    environment:
      - LEMMY_UI_LEMMY_INTERNAL_HOST=lemmy:8536
$ docker ps | grep lemmy-ui
5691ba6273d2   dvlemmyui                 "docker-entrypoint.s…"   About a minute ago   Up About a minute (healthy)   127.0.0.1:1235->1234/tcp   selfhost_lemmy-ui_1
```

And a misconfigured lemmy-ui container shows as unhealthy:
```
$ grep -A5 lemmy-ui docker-compose.yml
  lemmy-ui:
    image: dvlemmyui
    healthcheck:
      test: curl -f http://127.0.0.1:1234 || exit 1
    environment:
      - LEMMY_UI_LEMMY_INTERNAL_HOST=doesnt.exist:8536
$ docker ps | grep lemmy-ui
090161ee9d14   dvlemmyui                 "docker-entrypoint.s…"   About a minute ago   Up About a minute (unhealthy)   127.0.0.1:1235->1234/tcp   selfhost_lemmy-ui_1
```